### PR TITLE
Fix maximum concentration in positive electrode in test file

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -57,7 +57,7 @@ class TestSchema(unittest.TestCase):
                     "Porosity": 0.335,
                     "Transport efficiency": 0.1939,
                     "Reaction rate constant [mol.m-2.s-1]": 1e-10,
-                    "Maximum concentration [mol.m-3]": 631040,
+                    "Maximum concentration [mol.m-3]": 63104.0,
                     "Minimum stoichiometry": 0.1,
                     "Maximum stoichiometry": 0.9,
                 },

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -57,7 +57,7 @@ class TestUtlilities(unittest.TestCase):
                     "Porosity": 0.335,
                     "Transport efficiency": 0.1939,
                     "Reaction rate constant [mol.m-2.s-1]": 1e-10,
-                    "Maximum concentration [mol.m-3]": 631040,
+                    "Maximum concentration [mol.m-3]": 63104.0,
                     "Minimum stoichiometry": 0.1,
                     "Maximum stoichiometry": 0.9,
                 },
@@ -81,7 +81,7 @@ class TestUtlilities(unittest.TestCase):
         obj = parse_obj_as(BPX, test)
         x, y = get_electrode_concentrations(0.7, obj)
         self.assertAlmostEqual(x, 23060.568)
-        self.assertAlmostEqual(y, 214553.6)
+        self.assertAlmostEqual(y, 21455.36)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It was not actually a bug; the maximum concentrations in the test files can be arbitrary. The test only checks that the initial concentrations calculated from the provided maximum concentrations and the target SOC are correct.

Still, I have updated the maximum concentration in the test as suggested in issue #30 and updated the initial concentration test accordingly. This fix serves as a quick example for me to set up and test the workflow to address other issues in the project.
